### PR TITLE
Fix #66: Add default landing page

### DIFF
--- a/Projbook.nuspec
+++ b/Projbook.nuspec
@@ -41,6 +41,7 @@
     <file src="src/Projbook.Target/bin/Release/Projbook.Target.dll" target="tools" exclude="" />
     <file src="src/Projbook.Example/projbook.json" target="content" exclude="" />
     <file src="src/Projbook.Example/template.html" target="content" exclude="" />
+    <file src="src/Projbook.Example/index-template.html" target="content" exclude="" />
     <file src="src/Projbook.Example/template-pdf.html" target="content" exclude="" />
     <file src="src/Projbook.Example/Content/prism.css" target="content/Content" exclude="" />
     <file src="src/Projbook.Example/Content/projbook.css" target="content/Content" exclude="" />

--- a/src/Projbook.Core/Projbook/Core/ConfigurationLoader.cs
+++ b/src/Projbook.Core/Projbook/Core/ConfigurationLoader.cs
@@ -40,7 +40,7 @@ namespace Projbook.Core
         }
 
         /// <summary>
-        /// Load the configuraiton
+        /// Load the configuration.
         /// </summary>
         /// <param name="projectLocation">The project location.</param>
         /// <param name="configurationFile">The configuration to load.</param>
@@ -64,7 +64,7 @@ namespace Projbook.Core
                 // Read the content
                 content = reader.ReadToEnd();
 
-                // Deserialize as contiguration array if the configuration content looks containing many generation configuraiton
+                // Deserialize as configuration array if the configuration content looks containing many generation configuration
                 try
                 {
                     // Prepare configuration parsing
@@ -79,7 +79,7 @@ namespace Projbook.Core
                         JSchema schemaJson = JSchema.Parse(ConfigurationValidation.ConfigurationArraySchema);
                         jsonValidatingReader.Schema = schemaJson;
 
-                        // Deserialize condiguration
+                        // Deserialize configuration
                         configurations = jsonSerializer.Deserialize<Configuration[]>(jsonValidatingReader);
                     }
 
@@ -90,7 +90,7 @@ namespace Projbook.Core
                         JSchema schemaJson = JSchema.Parse(ConfigurationValidation.ConfigurationSchema);
                         jsonValidatingReader.Schema = schemaJson;
                         
-                        // Deserialize condiguration
+                        // Deserialize configuration
                         configurations = new Configuration[] { jsonSerializer.Deserialize<Configuration>(jsonValidatingReader) };
                     }
                 }

--- a/src/Projbook.Core/Projbook/Core/Markdown/ProjbookHtmlFormatter.cs
+++ b/src/Projbook.Core/Projbook/Core/Markdown/ProjbookHtmlFormatter.cs
@@ -35,8 +35,8 @@ namespace Projbook.Core.Markdown
 
         /// <summary>
         /// Internal dictionary to resolve section conflicts.
-        /// In case of no conflict the dictionary will remaings empty, however any conflict will create a slot with an integer representing the next available index.
-        /// Everytime we meet a conflict, the section generation will increment the index and use it as suffix.
+        /// In case of no conflict the dictionary will remain empty, however any conflict will create a slot with an integer representing the next available index.
+        /// Every time we meet a conflict, the section generation will increment the index and use it as suffix.
         /// </summary>
         private Dictionary<string, int> sectionConflict = new Dictionary<string, int>();
 
@@ -64,7 +64,7 @@ namespace Projbook.Core.Markdown
         /// Initializes a new instance of <see cref="ProjbookHtmlFormatter"/>.
         /// </summary>
         /// <param name="contextName">Initializes the required <see cref="ContextName"/></param>
-        /// <param name="target">Initializes the required text writter used as output.</param>
+        /// <param name="target">Initializes the required text writer used as output.</param>
         /// <param name="settings">Initializes the required common mark settings used by the formatting.</param>
         /// <param name="sectionTitleBase">Initializes the section title base.</param>
         public ProjbookHtmlFormatter(string contextName, TextWriter target, CommonMarkSettings settings, int sectionTitleBase)

--- a/src/Projbook.Core/Projbook/Core/ProjbookEngine.cs
+++ b/src/Projbook.Core/Projbook/Core/ProjbookEngine.cs
@@ -17,8 +17,10 @@ using System.IO.Abstractions;
 using System.Linq;
 using System.Xml;
 using WkHtmlToXSharp;
+using Projbook.Core.Model;
+using Page = Projbook.Core.Model.Configuration.Page;
 
-namespace Projbook.Core
+namespace Projbook.Core 
 {
     /// <summary>
     /// Entry point for document generation.
@@ -33,9 +35,9 @@ namespace Projbook.Core
         public FileInfoBase CsprojFile { get; private set; }
 
         /// <summary>
-        /// The configuration.
+        /// The configurations.
         /// </summary>
-        public Configuration Configuration { get; private set; }
+        public Configuration[] Configurations { get; private set; }
 
         /// <summary>
         /// The output directory where generated content will be written.
@@ -69,32 +71,53 @@ namespace Projbook.Core
         /// <param name="csprojFile">Initializes the required <see cref="CsprojFile"/>.</param>
         /// <param name="configuration">Initializes the required <see cref="Configuration"/>.</param>
         /// <param name="outputDirectoryPath">Initializes the required <see cref="OutputDirectory"/>.</param>
-        public ProjbookEngine(IFileSystem fileSystem, string csprojFile, Configuration configuration, string outputDirectoryPath)
+        public ProjbookEngine(IFileSystem fileSystem, string csprojFile, Configuration[] configurations, string outputDirectoryPath)
         {
             // Data validation
             Ensure.That(() => fileSystem).IsNotNull();
             Ensure.That(() => csprojFile).IsNotNullOrWhiteSpace();
-            Ensure.That(() => configuration).IsNotNull();
+            Ensure.That(() => configurations).HasItems();
             Ensure.That(() => outputDirectoryPath).IsNotNullOrWhiteSpace();
             Ensure.That(fileSystem.File.Exists(csprojFile), string.Format("Could not find '{0}' file", csprojFile)).IsTrue();
 
             // Initialize
             this.fileSystem = fileSystem;
             this.CsprojFile = this.fileSystem.FileInfo.FromFileName(csprojFile);
-            this.Configuration = configuration;
+            this.Configurations = configurations;
             this.OutputDirectory = this.fileSystem.DirectoryInfo.FromDirectoryName(outputDirectoryPath);
             this.snippetExtractorFactory = new SnippetExtractorFactory();
+        }
+
+        public GenerationError[] GenerateAll()
+        {
+            // Run generation for each configuration
+            List<GenerationError> errors = new List<GenerationError>();
+            foreach (Configuration configuration in this.Configurations)
+            {
+                // Generate the documentation
+                errors.AddRange(this.Generate(configuration));
+            }
+
+            // Generate the index html file for the configurations that call for html generation
+            Configuration[] htmlConfigurations = this.Configurations.Where(configuration => configuration.GenerateHtml).ToArray();
+            if (htmlConfigurations.Length > 0)
+            {
+                this.GenerateIndex(htmlConfigurations);
+            }
+
+            // Report processing successful
+            return errors.ToArray();
         }
 
         /// <summary>
         /// Generates documentation.
         /// </summary>
-        public Model.GenerationError[] Generate()
+        public Model.GenerationError[] Generate(Configuration configuration)
         {
             // Initialize the list containing all generation errors
             List<Model.GenerationError> generationError = new List<Model.GenerationError>();
 
-            // Ensute output directory exists
+            // Ensure output directory exists
             if (!this.OutputDirectory.Exists)
             {
                 this.OutputDirectory.Create();
@@ -102,7 +125,7 @@ namespace Projbook.Core
             
             // Process all pages
             List<Model.Page> pages = new List<Model.Page>();
-            foreach (Page page in this.Configuration.Pages)
+            foreach (Page page in configuration.Pages)
             {
                 // Compute the page id used as a tab id and page prefix for bookmarking
                 string pageId = page.Path.Replace(".", string.Empty).Replace("/", string.Empty);
@@ -124,7 +147,7 @@ namespace Projbook.Core
                     // Filter fenced code
                     if (node.Block != null && node.Block.Tag == BlockTag.FencedCode)
                     {
-                        // Buil extraction rule
+                        // Build extraction rule
                         string fencedCode = node.Block.FencedCodeData.Info;
                         SnippetExtractionRule snippetExtractionRule = SnippetExtractionRule.Parse(fencedCode);
                         
@@ -153,7 +176,7 @@ namespace Projbook.Core
                                     directoryInfos = this.ExtractSourceDirectories(this.CsprojFile);
                                     foreach (DirectoryInfoBase directoryInfo in directoryInfos)
                                     {
-                                        // Get direcotry name
+                                        // Get directory name
                                         string directoryName = directoryInfo.FullName;
                                         if (1 == directoryName.Length && Path.DirectorySeparatorChar == directoryName[0])
                                             directoryName = string.Empty;
@@ -246,7 +269,7 @@ namespace Projbook.Core
                 using (StreamWriter writer = new StreamWriter(documentStream))
                 {
                     // Setup custom formatter
-                    CommonMarkSettings.Default.OutputDelegate = (d, o, s) => (projbookHtmlFormatter = new ProjbookHtmlFormatter(pageId, o, s, this.Configuration.SectionTitleBase)).WriteDocument(d);
+                    CommonMarkSettings.Default.OutputDelegate = (d, o, s) => (projbookHtmlFormatter = new ProjbookHtmlFormatter(pageId, o, s, configuration.SectionTitleBase)).WriteDocument(d);
 
                     // Render
                     CommonMarkConverter.ProcessStage3(document, writer);
@@ -307,31 +330,31 @@ namespace Projbook.Core
             }
 
             // Html generation
-            if (this.Configuration.GenerateHtml)
+            if (configuration.GenerateHtml)
             {
                 try
                 {
-                    string outputFileHtml = this.fileSystem.Path.Combine(this.OutputDirectory.FullName, this.Configuration.OutputHtml);
-                    this.GenerateFile(this.Configuration.TemplateHtml, outputFileHtml, this.Configuration, pages);  
+                    string outputFileHtml = this.fileSystem.Path.Combine(this.OutputDirectory.FullName, configuration.OutputHtml);
+                    this.GenerateFile(configuration.TemplateHtml, outputFileHtml, configuration, pages);  
                 }
                 catch (TemplateParsingException templateParsingException)
                 {
-                    generationError.Add(new Model.GenerationError(this.Configuration.TemplateHtml, string.Format("Error during HTML generation: {0}", templateParsingException.Message), templateParsingException.Line, templateParsingException.Column));
+                    generationError.Add(new Model.GenerationError(configuration.TemplateHtml, string.Format("Error during HTML generation: {0}", templateParsingException.Message), templateParsingException.Line, templateParsingException.Column));
                 }
                 catch (System.Exception exception)
                 {
-                    generationError.Add(new Model.GenerationError(this.Configuration.TemplateHtml, string.Format("Error during HTML generation: {0}", exception.Message), 0, 0));
+                    generationError.Add(new Model.GenerationError(configuration.TemplateHtml, string.Format("Error during HTML generation: {0}", exception.Message), 0, 0));
                 }
             }
 
             // Pdf generation
-            if (this.Configuration.GeneratePdf)
+            if (configuration.GeneratePdf)
             {
                 try
                 {
                     // Generate the pdf template
-                    string outputFileHtml = this.fileSystem.Path.Combine(this.OutputDirectory.FullName, this.Configuration.OutputPdf);
-                    this.GenerateFile(this.Configuration.TemplatePdf, outputFileHtml, this.Configuration, pages);
+                    string outputFileHtml = this.fileSystem.Path.Combine(this.OutputDirectory.FullName, configuration.OutputPdf);
+                    this.GenerateFile(configuration.TemplatePdf, outputFileHtml, configuration, pages);
 
 #if !NOPDF
                     // Register bundles
@@ -341,14 +364,14 @@ namespace Projbook.Core
                     WkHtmlToXLibrariesManager.Register(new Win64NativeBundle());
 
                     // Compute file names
-                    string outputPdf = this.fileSystem.Path.ChangeExtension(this.Configuration.OutputPdf, ".pdf");
+                    string outputPdf = this.fileSystem.Path.ChangeExtension(configuration.OutputPdf, ".pdf");
                     string outputFilePdf = this.fileSystem.Path.Combine(this.OutputDirectory.FullName, outputPdf);
 
                     // Prepare the converter
                     MultiplexingConverter pdfConverter = new MultiplexingConverter();
                     pdfConverter.ObjectSettings.Page = outputFileHtml;
                     pdfConverter.Error += (s, e) => {
-                        generationError.Add(new Model.GenerationError(this.Configuration.TemplatePdf, string.Format("Error during PDF generation: {0}", e.Value), 0, 0));
+                        generationError.Add(new Model.GenerationError(configuration.TemplatePdf, string.Format("Error during PDF generation: {0}", e.Value), 0, 0));
                     };
 
                     // Prepare file system if abstracted
@@ -362,7 +385,7 @@ namespace Projbook.Core
                             File.WriteAllBytes(outputFileHtml, this.fileSystem.File.ReadAllBytes(outputFileHtml));
                         }
                         
-                        // Run pdf convertion
+                        // Run pdf converter
                         using (pdfConverter)
                         using (Stream outputFileStream = this.fileSystem.File.Open(outputFilePdf, FileMode.Create, FileAccess.Write, FileShare.None))
                         {
@@ -389,7 +412,7 @@ namespace Projbook.Core
                 }
                 catch (TemplateParsingException templateParsingException)
                 {
-                    generationError.Add(new Model.GenerationError(this.Configuration.TemplatePdf, string.Format("Error during PDF generation: {0}", templateParsingException.Message), templateParsingException.Line, templateParsingException.Column));
+                    generationError.Add(new Model.GenerationError(configuration.TemplatePdf, string.Format("Error during PDF generation: {0}", templateParsingException.Message), templateParsingException.Line, templateParsingException.Column));
                 }
                 catch (System.Exception exception)
                 {
@@ -398,18 +421,35 @@ namespace Projbook.Core
                         // Report detailed error message for wrong architecture loading
                         string runningArchitectureProccess = IntPtr.Size == 8 ? "x64" : "x86";
                         string otherRunningArchitectureProccess = IntPtr.Size != 8 ? "x64" : "x86";
-                        generationError.Add(new Model.GenerationError(this.Configuration.TemplatePdf, string.Format("Error during PDF generation: Could not load wkhtmltopdf for {0}. Try again running as a {1} process.", runningArchitectureProccess, otherRunningArchitectureProccess), 0, 0));
+                        generationError.Add(new Model.GenerationError(configuration.TemplatePdf, string.Format("Error during PDF generation: Could not load wkhtmltopdf for {0}. Try again running as a {1} process.", runningArchitectureProccess, otherRunningArchitectureProccess), 0, 0));
                     }
                     else
                     {
                         // Report unknown error
-                        generationError.Add(new Model.GenerationError(this.Configuration.TemplatePdf, string.Format("Error during PDF generation: {0}", exception.Message), 0, 0));
+                        generationError.Add(new Model.GenerationError(configuration.TemplatePdf, string.Format("Error during PDF generation: {0}", exception.Message), 0, 0));
                     }
                 }
             }
 
             // Return the generation errors
             return generationError.ToArray();
+        }
+
+        /// <summary>
+        /// Generates the index page for the documentation.
+        /// </summary>
+        public void GenerateIndex(Configuration[] configurations)
+        {
+            // Try to generate the index html file
+            try
+            {
+                string outputFileHtml = this.fileSystem.Path.Combine(this.OutputDirectory.FullName, "index.html");
+                this.GenerateIndexFile("index-template.html", outputFileHtml, configurations);
+            }
+            catch
+            {
+                // For now suppress errors from generating the index file
+            }
         }
 
         /// <summary>
@@ -436,6 +476,31 @@ namespace Projbook.Core
         private void GenerateFile(string templateName, string outputFileHtml, Configuration configuration, List<Model.Page> pages)
         {
             // Generate final documentation from the template using razor engine
+            var fileConfiguration = new { Title = configuration.Title, Pages = pages };
+            this.WriteFile(templateName, outputFileHtml, fileConfiguration);
+        }
+
+        /// <summary>
+        /// Generates the index file.
+        /// </summary>
+        /// <param name="templateName">The template name.</param>
+        /// <param name="outputFileHtml">The file to output to.</param>
+        /// <param name="configurations">The configuration.</param>
+        private void GenerateIndexFile(string templateName, string outputFileHtml, Configuration[] configurations)
+        {
+            // Generate the index html for the configurations using Razor
+            var fileConfiguration = new { Configurations = configurations };
+            this.WriteFile(templateName, outputFileHtml, fileConfiguration);
+        }
+
+        /// <summary>
+        /// Write to the documentation file.
+        /// </summary>
+        /// <param name="templateName">The template name.</param>
+        /// <param name="outputFileHtml">The file to output to.</param>
+        /// <param name="fileConfiguration">The file configuration object.</param>
+        private void WriteFile(string templateName, string outputFileHtml, Object fileConfiguration)
+        {
             using (var reader = new StreamReader(this.fileSystem.File.Open(templateName, FileMode.Open, FileAccess.Read, FileShare.Read)))
             using (var writer = new StreamWriter(this.fileSystem.File.Open(outputFileHtml, FileMode.Create, FileAccess.Write, FileShare.None)))
             {
@@ -444,7 +509,7 @@ namespace Projbook.Core
                 config.EncodedStringFactory = new RawStringFactory();
                 var service = RazorEngineService.Create(config);
                 Engine.Razor = service;
-                string processed = Engine.Razor.RunCompile(new LoadedTemplateSource(reader.ReadToEnd()), string.Empty, null, new { Title = configuration.Title, Pages = pages });
+                string processed = Engine.Razor.RunCompile(new LoadedTemplateSource(reader.ReadToEnd()), string.Empty, null, fileConfiguration);
                 writer.WriteLine(processed);
             }
         }
@@ -483,7 +548,7 @@ namespace Projbook.Core
 
         /// <summary>
         /// Extracts source directories from the csproj file.
-        /// The extected directory info list is the csproj's directory and all project references.
+        /// The expected directory info list is the csproj's directory and all project references.
         /// </summary>
         /// <param name="csprojFile"></param>
         /// <returns></returns>
@@ -526,7 +591,7 @@ namespace Projbook.Core
                 extractedSourceDirectories.Add(this.fileSystem.DirectoryInfo.FromDirectoryName(this.fileSystem.Path.GetDirectoryName(this.fileSystem.Path.GetFullPath(combinedPath))));
             }
 
-            // Returne the extracted directories
+            // Return the extracted directories
             return extractedSourceDirectories.ToArray();
         }
     }

--- a/src/Projbook.Core/Projbook/Core/ProjbookEngine.cs
+++ b/src/Projbook.Core/Projbook/Core/ProjbookEngine.cs
@@ -2,6 +2,7 @@
 using CommonMark.Syntax;
 using EnsureThat;
 using Projbook.Core.Markdown;
+using Projbook.Core.Model;
 using Projbook.Core.Model.Configuration;
 using Projbook.Core.Snippet;
 using Projbook.Extension.Exception;
@@ -17,7 +18,6 @@ using System.IO.Abstractions;
 using System.Linq;
 using System.Xml;
 using WkHtmlToXSharp;
-using Projbook.Core.Model;
 using Page = Projbook.Core.Model.Configuration.Page;
 
 namespace Projbook.Core 

--- a/src/Projbook.Example/Projbook.Example.csproj
+++ b/src/Projbook.Example/Projbook.Example.csproj
@@ -65,6 +65,7 @@
     <Content Include="Content\projbook.css">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="index-template.html" />
     <Content Include="Scripts\prism.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/Projbook.Example/index-template.html
+++ b/src/Projbook.Example/index-template.html
@@ -1,0 +1,33 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <!-- Bootstrap -->
+    <link href="Content/bootstrap.min.css" rel="stylesheet">
+    <link href="Content/bootstrap-theme.min.css" rel="stylesheet">
+    <!-- Prism -->
+    <script src="Scripts/prism.js"></script>
+    <link href="Content/prism.css" rel="stylesheet" />
+    <!-- Projbook -->
+    <link href="Content/projbook.css" rel="stylesheet">
+</head>
+<body role="document">
+    <div class="container">
+        <div class="row">
+            <ul>
+                @foreach (var configuration in Model.Configurations)
+                {
+                <li><a href="@(configuration.OutputHtml)">@(configuration.Title)</a></li>
+                }
+            </ul>
+        </div>
+    </div>
+    <script src="Scripts/jquery-1.9.0.min.js"></script>
+    <script src="Scripts/bootstrap.min.js"></script>
+    <script src="Scripts/projbook.js"></script>
+</body>
+</html>

--- a/src/Projbook.Extension.XmlExtractor/Projbook/Extension/Xml/XmlSnippetExtractor.cs
+++ b/src/Projbook.Extension.XmlExtractor/Projbook/Extension/Xml/XmlSnippetExtractor.cs
@@ -149,7 +149,7 @@ namespace Projbook.Extension.XmlExtractor
             string output = stringBuilder.ToString();
             output = Regex.Replace(output, @" ?xmlns\s*(:[^=]+)?\s*=\s*""[^""]*""", string.Empty);
 
-            // Create the snippet from the exctracted code
+            // Create the snippet from the extracted code
             return new Extension.Model.Snippet(output);
         }
     }

--- a/src/Projbook.Target/Projbook.cs
+++ b/src/Projbook.Target/Projbook.cs
@@ -11,7 +11,7 @@ using System.IO.Abstractions;
 namespace Projbook.Target
 {
     /// <summary>
-    /// Define MSBuild task trigerring documentation generation.
+    /// Define MSBuild task triggering documentation generation.
     /// </summary>
     public class Projbook : Task
     {
@@ -59,23 +59,20 @@ namespace Projbook.Target
                 return false;
             }
 
-            // Run generation for each configuration
+            // Instantiate a ProjBook engine
+            ProjbookEngine projbookEngine = new ProjbookEngine(fileSystem, this.ProjectPath, configurations, this.OutputDirectory);
+
+            // Run generation
             bool success = true;
-            foreach (Configuration configuration in configurations)
-            {
-                // Run generation
-                ProjbookEngine projbookEngine = new ProjbookEngine(fileSystem, this.ProjectPath, configuration, this.OutputDirectory);
-                GenerationError[] errors = projbookEngine.Generate();
+            GenerationError[] errors = projbookEngine.GenerateAll();
 
-                // Report generation errors
-                this.ReportErrors(errors);
+            // Report generation errors
+            this.ReportErrors(errors);
 
-                // Stop processing in case of error
-                if (errors.Length > 0)
-                    success = false;
-            }
+            // Stop processing in case of error
+            if (errors.Length > 0)
+                success = false;
 
-            // Report processing successful
             return success;
         }
 

--- a/src/Projbook.Target/Projbook.cs
+++ b/src/Projbook.Target/Projbook.cs
@@ -59,7 +59,7 @@ namespace Projbook.Target
                 return false;
             }
 
-            // Instantiate a ProjBook engine
+            // Instantiate a Projbook engine
             ProjbookEngine projbookEngine = new ProjbookEngine(fileSystem, this.ProjectPath, configurations, this.OutputDirectory);
 
             // Run generation

--- a/src/Projbook.Tests/Projbook.Tests.csproj
+++ b/src/Projbook.Tests/Projbook.Tests.csproj
@@ -193,6 +193,7 @@
     <Content Include="Resources\Expected\CSharp\I.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Resources\Expected\FullGeneration\SimpleIndex.txt" />
     <Content Include="Resources\Expected\Xml\SecondLevel.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -319,6 +320,7 @@
     <Compile Include="Projbook\Tests\Core\Markdown\ProjbookHtmlFormatterTests.cs" />
     <Compile Include="Projbook\Tests\Core\Snippet\SnippetExtractorFactoryTests.cs" />
     <Compile Include="Projbook\Tests\Core\Snippet\CSharpSnippetExtractorTests.cs" />
+    <Content Include="Resources\Template\SimpleIndex.txt" />
     <None Include="Resources\Source\Xml\Projbook.Core.csproj" />
     <Content Include="Resources\Source\Xml\SimpleNoNamespace.xml">
       <SubType>Designer</SubType>

--- a/src/Projbook.Tests/Projbook/Tests/FullGenerationTests.cs
+++ b/src/Projbook.Tests/Projbook/Tests/FullGenerationTests.cs
@@ -52,7 +52,7 @@ namespace Projbook.Tests.Core
         }
 
         /// <summary>
-        /// Run the full generation and compate the generated output with the expected output.
+        /// Run the full generation and compare the generated output with the expected output.
         /// </summary>
         /// <param name="configFileName">The config file name.</param>
         /// <param name="expectedHtmlFileName">The file name containing the expected content for HTML generation.</param>
@@ -68,7 +68,8 @@ namespace Projbook.Tests.Core
         public void FullGeneration(string configFileName, string expectedHtmlFileName, string expectedPdfFileName, string generatedHtmlFileName, string generatedPdfFileName, bool readOnly)
         {
             // Prepare configuration
-            Configuration configuration = new ConfigurationLoader(this.FileSystem).Load(".", configFileName)[0];
+            Configuration[] configurations = new ConfigurationLoader(this.FileSystem).Load(".", configFileName);
+            Configuration configuration = configurations[0];
             string htmlTemplatePath = configuration.TemplateHtml;
             string pdfTemplatePath = configuration.TemplatePdf;
             string firstPagePath = new FileInfo(configuration.Pages.First().Path).FullName;
@@ -115,7 +116,7 @@ namespace Projbook.Tests.Core
             try
             {
                 // Execute generation
-                GenerationError[] errors = new ProjbookEngine(this.FileSystem, "Project.csproj", configuration, ".").Generate();
+                GenerationError[] errors = new ProjbookEngine(this.FileSystem, "Project.csproj", configurations, ".").GenerateAll();
 
                 // Read expected ouput
                 string expectedContent = string.IsNullOrWhiteSpace(expectedHtmlFileName) ? string.Empty : this.FileSystem.File.ReadAllText(expectedHtmlFileName);
@@ -172,8 +173,8 @@ namespace Projbook.Tests.Core
         public void FullGenerationErrorTemplate()
         {
             // Perform generation
-            Configuration configuration = new ConfigurationLoader(this.FileSystem).Load(".", "Config/ErrorInHtml.json")[0];
-            GenerationError[] errors = new ProjbookEngine(this.FileSystem, "Project.csproj", configuration, ".").Generate();
+            Configuration[] configurations = new ConfigurationLoader(this.FileSystem).Load(".", "Config/ErrorInHtml.json");
+            GenerationError[] errors = new ProjbookEngine(this.FileSystem, "Project.csproj", configurations, ".").GenerateAll();
 
             // Assert result
             Assert.IsNotNull(errors);
@@ -196,8 +197,8 @@ namespace Projbook.Tests.Core
         public void FullGenerationUnexistingMembers()
         {
             // Perform generation
-            Configuration configuration = new ConfigurationLoader(this.FileSystem).Load(".", "Config/MissingMembersInPage.json")[0];
-            GenerationError[] errors = new ProjbookEngine(this.FileSystem, "Project.csproj", configuration, ".").Generate();
+            Configuration[] configurations = new ConfigurationLoader(this.FileSystem).Load(".", "Config/MissingMembersInPage.json");
+            GenerationError[] errors = new ProjbookEngine(this.FileSystem, "Project.csproj", configurations, ".").GenerateAll();
 
             // Assert result
             Assert.IsNotNull(errors);

--- a/src/Projbook.Tests/Resources/Expected/FullGeneration/SimpleIndex.txt
+++ b/src/Projbook.Tests/Resources/Expected/FullGeneration/SimpleIndex.txt
@@ -1,0 +1,2 @@
+﻿<Title>Test title</Title>
+<OutputHtml>doc.html</OutputHtml>

--- a/src/Projbook.Tests/Resources/ExpectedFullGenerationFiles.Designer.cs
+++ b/src/Projbook.Tests/Resources/ExpectedFullGenerationFiles.Designer.cs
@@ -62,13 +62,13 @@ namespace Projbook.Tests.Resources {
         
         /// <summary>
         ///   Looks up a localized string similar to &lt;Title&gt;Test title&lt;/Title&gt;
-        ///    &lt;Id&gt;ResourcesFullGenerationPagefirstPagemd&lt;/Id&gt;
+        ///    &lt;Id&gt;PageContentmd&lt;/Id&gt;
         ///    &lt;Title&gt;First page title&lt;/Title&gt;
         ///	&lt;PreSectionContent&gt;&lt;![CDATA[&lt;p&gt;Before section…&lt;/p&gt;
         ///]]&gt;&lt;/PreSectionContent&gt;
         ///	&lt;Sections&gt;
         ///        &lt;Section&gt;
-        ///			&lt;Id&gt;ResourcesFullGenerationPagefirstPagemd-foo&lt;/Id&gt;
+        ///			&lt;Id&gt;PageContentmd-foo&lt;/Id&gt;
         ///			&lt;Title&gt;Foo&lt;/Title&gt;
         ///			&lt;Content&gt;
         ///				&lt;![CDATA[
@@ -77,11 +77,16 @@ namespace Projbook.Tests.Resources {
         ///			&lt;/Content&gt;
         ///        &lt;/Section&gt;
         ///        &lt;Section&gt;
-        ///			&lt;Id&gt;ResourcesFullGenerationPagefirstPagemd-sub-foo&lt;/Id&gt;
+        ///			&lt;Id&gt;PageContentmd-sub-foo&lt;/Id&gt;
         ///			&lt;Title&gt;Sub-foo&lt;/Title&gt;
         ///			&lt;Content&gt;
         ///				&lt;![CDATA[
-        ///&lt;h2&gt;Sub- [rest of string was truncated]&quot;;.
+        ///&lt;h2&gt;Sub-foo&lt;/h2&gt;
+        ///]]&gt;
+        ///			&lt;/Content&gt;
+        ///        &lt;/Section&gt;
+        ///	&lt;/Sections&gt;
+        ///    &lt;Id&gt;PageSnip [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string Simple {
             get {
@@ -91,13 +96,13 @@ namespace Projbook.Tests.Resources {
         
         /// <summary>
         ///   Looks up a localized string similar to &lt;Title&gt;Test title - PDF&lt;/Title&gt;
-        ///    &lt;Id&gt;ResourcesFullGenerationPagefirstPagemd&lt;/Id&gt;
+        ///    &lt;Id&gt;PageContentmd&lt;/Id&gt;
         ///    &lt;Title&gt;First page title&lt;/Title&gt;
         ///	&lt;PreSectionContent&gt;&lt;![CDATA[&lt;p&gt;Before section…&lt;/p&gt;
         ///]]&gt;&lt;/PreSectionContent&gt;
         ///	&lt;Sections&gt;
         ///        &lt;Section&gt;
-        ///			&lt;Id&gt;ResourcesFullGenerationPagefirstPagemd-foo&lt;/Id&gt;
+        ///			&lt;Id&gt;PageContentmd-foo&lt;/Id&gt;
         ///			&lt;Title&gt;Foo&lt;/Title&gt;
         ///			&lt;Content&gt;
         ///				&lt;![CDATA[
@@ -106,15 +111,30 @@ namespace Projbook.Tests.Resources {
         ///			&lt;/Content&gt;
         ///        &lt;/Section&gt;
         ///        &lt;Section&gt;
-        ///			&lt;Id&gt;ResourcesFullGenerationPagefirstPagemd-sub-foo&lt;/Id&gt;
+        ///			&lt;Id&gt;PageContentmd-sub-foo&lt;/Id&gt;
         ///			&lt;Title&gt;Sub-foo&lt;/Title&gt;
         ///			&lt;Content&gt;
         ///				&lt;![CDATA[
-        ///&lt;h [rest of string was truncated]&quot;;.
+        ///&lt;h2&gt;Sub-foo&lt;/h2&gt;
+        ///]]&gt;
+        ///			&lt;/Content&gt;
+        ///        &lt;/Section&gt;
+        ///	&lt;/Sections&gt;
+        ///    &lt;Id&gt;Pa [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string Simple_pdf {
             get {
                 return ResourceManager.GetString("Simple_pdf", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;Title&gt;Test Title&lt;/Title&gt;
+        ///&lt;OutputHtml&gt;doc.html&lt;/OutputHtml&gt;.
+        /// </summary>
+        internal static string SimpleIndex {
+            get {
+                return ResourceManager.GetString("SimpleIndex", resourceCulture);
             }
         }
     }

--- a/src/Projbook.Tests/Resources/ExpectedFullGenerationFiles.resx
+++ b/src/Projbook.Tests/Resources/ExpectedFullGenerationFiles.resx
@@ -121,6 +121,9 @@
   <data name="Simple" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Expected\FullGeneration\Simple.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
+  <data name="SimpleIndex" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>expected\fullgeneration\simpleindex.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
   <data name="Simple_pdf" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Expected\FullGeneration\Simple-pdf.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>

--- a/src/Projbook.Tests/Resources/Source/CSharp/Sample.cs
+++ b/src/Projbook.Tests/Resources/Source/CSharp/Sample.cs
@@ -1,104 +1,104 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿//using System;
+//using System.Collections.Generic;
+//using System.Linq;
+//using System.Text;
+//using System.Threading.Tasks;
 
-namespace NS
-{
-    public class OneClassSomewhere
-    {
-        private class SubClass
-        {
-            public int WhateverProperty
-            {
-                get
-                {
-                    return 42;
-                }
-                set
-                {
-                    string foo = "foo";
-                }
-            }
-        }
+//namespace NS
+//{
+//    public class OneClassSomewhere
+//    {
+//        private class SubClass
+//        {
+//            public int WhateverProperty
+//            {
+//                get
+//                {
+//                    return 42;
+//                }
+//                set
+//                {
+//                    string foo = "foo";
+//                }
+//            }
+//        }
 
-        protected bool Foo(string foo)
-        {
-            return true;
-        }
+//        protected bool Foo(string foo)
+//        {
+//            return true;
+//        }
 
-        protected bool Foo(string foo, int bar)
-        {
-            return false;
-        }
-    }
-    namespace NS2.NS3
-    {
-        class A
-        {
-            // In NS.NS2.NS3
-        }
-    }
-}
+//        protected bool Foo(string foo, int bar)
+//        {
+//            return false;
+//        }
+//    }
+//    namespace NS2.NS3
+//    {
+//        class A
+//        {
+//            // In NS.NS2.NS3
+//        }
+//    }
+//}
 
-namespace NS2
-{
-    namespace NS2.NS3
-    {
-        class A
-        {
-            // In NS2.NS2.NS3
-        }
+//namespace NS2
+//{
+//    namespace NS2.NS3
+//    {
+//        class A
+//        {
+//            // In NS2.NS2.NS3
+//        }
 
-        class B
-        {
-            B(int foo)
-            {
-            }
+//        class B
+//        {
+//            B(int foo)
+//            {
+//            }
 
-            ~B()
-            {
-            }
-        }
+//            ~B()
+//            {
+//            }
+//        }
 
-        class C<T, U>
-        {
-            void CMethod<X, Y>(X x, Y y)
-            {
-            }
-        }
+//        class C<T, U>
+//        {
+//            void CMethod<X, Y>(X x, Y y)
+//            {
+//            }
+//        }
 
-        class D
-        {
-            public int this[string s, int i]
-            {
-                get
-                {
-                    return 51;
-                }
-                set
-                {
-                    string bar = "bar";
-                }
-            }
+//        class D
+//        {
+//            public int this[string s, int i]
+//            {
+//                get
+//                {
+//                    return 51;
+//                }
+//                set
+//                {
+//                    string bar = "bar";
+//                }
+//            }
 
-            public event Action Event
-            {
-                add
-                {
-                    // Add content
-                }
-                remove
-                {
-                    // Remove content
-                }
-            }
-        }
+//            public event Action Event
+//            {
+//                add
+//                {
+//                    // Add content
+//                }
+//                remove
+//                {
+//                    // Remove content
+//                }
+//            }
+//        }
 
-        interface I
-        {
-            void InterfaceMethod(bool v1, string v2, int v3);
-        }
-    }
-}
+//        interface I
+//        {
+//            void InterfaceMethod(bool v1, string v2, int v3);
+//        }
+//    }
+//}

--- a/src/Projbook.Tests/Resources/Source/CSharp/Sample.cs
+++ b/src/Projbook.Tests/Resources/Source/CSharp/Sample.cs
@@ -1,104 +1,104 @@
-﻿//using System;
-//using System.Collections.Generic;
-//using System.Linq;
-//using System.Text;
-//using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
-//namespace NS
-//{
-//    public class OneClassSomewhere
-//    {
-//        private class SubClass
-//        {
-//            public int WhateverProperty
-//            {
-//                get
-//                {
-//                    return 42;
-//                }
-//                set
-//                {
-//                    string foo = "foo";
-//                }
-//            }
-//        }
+namespace NS
+{
+    public class OneClassSomewhere
+    {
+        private class SubClass
+        {
+            public int WhateverProperty
+            {
+                get
+                {
+                    return 42;
+                }
+                set
+                {
+                    string foo = "foo";
+                }
+            }
+        }
 
-//        protected bool Foo(string foo)
-//        {
-//            return true;
-//        }
+        protected bool Foo(string foo)
+        {
+            return true;
+        }
 
-//        protected bool Foo(string foo, int bar)
-//        {
-//            return false;
-//        }
-//    }
-//    namespace NS2.NS3
-//    {
-//        class A
-//        {
-//            // In NS.NS2.NS3
-//        }
-//    }
-//}
+        protected bool Foo(string foo, int bar)
+        {
+            return false;
+        }
+    }
+    namespace NS2.NS3
+    {
+        class A
+        {
+            // In NS.NS2.NS3
+        }
+    }
+}
 
-//namespace NS2
-//{
-//    namespace NS2.NS3
-//    {
-//        class A
-//        {
-//            // In NS2.NS2.NS3
-//        }
+namespace NS2
+{
+    namespace NS2.NS3
+    {
+        class A
+        {
+            // In NS2.NS2.NS3
+        }
 
-//        class B
-//        {
-//            B(int foo)
-//            {
-//            }
+        class B
+        {
+            B(int foo)
+            {
+            }
 
-//            ~B()
-//            {
-//            }
-//        }
+            ~B()
+            {
+            }
+        }
 
-//        class C<T, U>
-//        {
-//            void CMethod<X, Y>(X x, Y y)
-//            {
-//            }
-//        }
+        class C<T, U>
+        {
+            void CMethod<X, Y>(X x, Y y)
+            {
+            }
+        }
 
-//        class D
-//        {
-//            public int this[string s, int i]
-//            {
-//                get
-//                {
-//                    return 51;
-//                }
-//                set
-//                {
-//                    string bar = "bar";
-//                }
-//            }
+        class D
+        {
+            public int this[string s, int i]
+            {
+                get
+                {
+                    return 51;
+                }
+                set
+                {
+                    string bar = "bar";
+                }
+            }
 
-//            public event Action Event
-//            {
-//                add
-//                {
-//                    // Add content
-//                }
-//                remove
-//                {
-//                    // Remove content
-//                }
-//            }
-//        }
+            public event Action Event
+            {
+                add
+                {
+                    // Add content
+                }
+                remove
+                {
+                    // Remove content
+                }
+            }
+        }
 
-//        interface I
-//        {
-//            void InterfaceMethod(bool v1, string v2, int v3);
-//        }
-//    }
-//}
+        interface I
+        {
+            void InterfaceMethod(bool v1, string v2, int v3);
+        }
+    }
+}

--- a/src/Projbook.Tests/Resources/Template/SimpleIndex.txt
+++ b/src/Projbook.Tests/Resources/Template/SimpleIndex.txt
@@ -1,0 +1,5 @@
+﻿@foreach (var configuration in Model.Configurations)
+{
+<Title>@configuration.Title</Title>
+<OutputHtml>@configuration.OutputHtml</OutputHtml>
+}

--- a/src/Projbook.Tests/Resources/TemplateFiles.Designer.cs
+++ b/src/Projbook.Tests/Resources/TemplateFiles.Designer.cs
@@ -139,5 +139,18 @@ namespace Projbook.Tests.Resources {
                 return ResourceManager.GetString("Simple_pdf", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to @foreach (var configuration in Model.Configurations)
+        ///{
+        ///    &lt;Title&gt;@configuration.Title&lt;/Title&gt;
+        ///	&lt;OutputHtml&gt;@configuration.OutputHtml&lt;/OutputHtml&gt;
+        ///}.
+        /// </summary>
+        internal static string SimpleIndex {
+            get {
+                return ResourceManager.GetString("SimpleIndex", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Projbook.Tests/Resources/TemplateFiles.resx
+++ b/src/Projbook.Tests/Resources/TemplateFiles.resx
@@ -124,6 +124,9 @@
   <data name="Simple" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Template\Simple.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
+  <data name="SimpleIndex" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>template\simpleindex.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
   <data name="Simple_pdf" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Template\Simple-pdf.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>


### PR DESCRIPTION
**Adds the following:**
- Projbook engine takes multiple configs via GenerateAll
- Adds GenerateIndex to engine to generate index html for all configs
- Adds index html support to FullGeneration test
- Adds starter index html template to example and includes in nuspec

**TODO:**
- Better presentation of example index html template
- Configurable index html (which would require a logical way to set this in config file)

**Disclaimer:**
Tests are green for generate all with index html, and if the index template exists in root directory, there is no generation error when error detection is added for generating the index html. But having trouble getting the actual file to generate in real-world example (still debugging it). Also for now, since there's no logical way to configure the index html template and output (it's static for now), I suppressed the generation error for the index html incase the template-index.html file is not in root dir.